### PR TITLE
resolve host and port to set of addresses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,8 @@ include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
 set(header_files
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/net/socket.hpp)
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/net/socket.hpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/net/address_resolver.hpp)
 
 add_library(${LIB_NAME} INTERFACE)
 target_sources(${LIB_NAME} INTERFACE "$<BUILD_INTERFACE:${header_files}>")

--- a/include/net/address_resolver.hpp
+++ b/include/net/address_resolver.hpp
@@ -1,0 +1,70 @@
+#ifndef NET_ADDRESS_RESOLVER_HPP
+#define NET_ADDRESS_RESOLVER_HPP
+
+#include <cstring>
+#include <exception>
+#include <netdb.h>
+#include <string>
+
+namespace net {
+
+    /// AddressInfoError Exception
+    class AddressInfoError : std::exception {
+    public:
+        explicit AddressInfoError(const std::string &msg) : msg_(msg) {}
+
+        [[nodiscard]] const char *what() const noexcept override {
+            return msg_.c_str();
+        }
+
+    private:
+        std::string msg_;
+    };
+
+
+    /// Network Address Translation
+    class AddressResolver {
+    public:
+        /// Default constructs an instance of an `AddressResolver`
+        AddressResolver() : addrInfo_(nullptr) {}
+
+        virtual ~AddressResolver() {
+            if (addrInfo_)
+                freeaddrinfo(addrInfo_);
+        }
+
+        /// Resolves the host and port to a set of socket addresses
+        ///
+        /// \param host hostname of the endpoint
+        /// \param port port of the endpoint
+        /// \return returns a linked list of addrinfo structures. On error, throws an exception of type
+        /// `AddressInfoError` with string describing the meaning of the error.
+        struct addrinfo *resolve(const std::string &host, const std::string &port) {
+            // The functionality to connect a socket to an endpoint is referenced from
+            // https://man7.org/linux/man-pages/man3/getaddrinfo.3.html
+
+            // Initialize hints for TCP socket (SOCK_STREAM) and IPv4 address (AF_INET)
+            struct addrinfo hints{};
+            memset(&hints, 0, sizeof hints);
+
+            // Specify AF_UNSPEC for any address family, e.g. IPv4 or IPv6
+            hints.ai_family = AF_UNSPEC;
+
+            // Specify 0 for any socket type, e.g. SOCK_STREAM or SOCK_DGRAM
+            hints.ai_socktype = 0;
+
+            // Allocates and initializes a linked list of addrinfo structures pointed to by addrInfo_
+            auto result = getaddrinfo(host.c_str(), port.c_str(), &hints, &addrInfo_);
+            if (result < 0) {
+                throw AddressInfoError(gai_strerror(result));
+            }
+            return addrInfo_;
+        }
+
+    private:
+        struct addrinfo *addrInfo_;
+    };
+
+}
+
+#endif //NET_ADDRESS_RESOLVER_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,3 +2,7 @@
 add_executable(stream_socket_tests src/socket_tests.cpp)
 target_link_libraries(stream_socket_tests ${LIB_NAME} ${CONAN_LIBS})
 add_test(NAME run_stream_socket_tests COMMAND stream_socket_tests)
+
+add_executable(address_resolver_tests src/address_resolver_tests.cpp)
+target_link_libraries(address_resolver_tests ${LIB_NAME} ${CONAN_LIBS})
+add_test(NAME run_address_resolver_tests COMMAND address_resolver_tests)

--- a/test/src/address_resolver_tests.cpp
+++ b/test/src/address_resolver_tests.cpp
@@ -1,0 +1,18 @@
+
+#include <net/address_resolver.hpp>
+#include "gtest/gtest.h"
+
+namespace {
+
+    TEST(AddressResolverTests, ResolveValidAddress) {
+        net::AddressResolver resolver;
+        auto *addressInfo = resolver.resolve("localhost", "40000");
+        EXPECT_TRUE(addressInfo);
+    }
+
+    TEST(AddressResolverTests, ResolveInvalidAddress) {
+        net::AddressResolver resolver;
+        EXPECT_ANY_THROW(resolver.resolve("foo", "bar"));
+    }
+
+}


### PR DESCRIPTION
- address resolver class as wrapper of getaddrinfo to 
  resolve host and port to set of addrinfo structures 
  for use by a socket to connect

closes #4 